### PR TITLE
Support wireless (portless) iOS/tvOS devices by honouring the existing 'wireless' field

### DIFF
--- a/roles/mac-devices/templates/mcloud-devices.txt
+++ b/roles/mac-devices/templates/mcloud-devices.txt
@@ -1,3 +1,3 @@
 {% for device in devices %}
-{{ device.id }}|{{ device.os }}|{{ device.name }}|{{ device.location | default('') }}|{{ device.appium_port }}|{{ device.adb_port }}|{{ device.proxy_port | default('0') }}|{{ device.server_proxy_port | default('0') }}|{{ device.min_port }}|{{ device.max_port }}|{{ device.wireless | default('false') }}|{{ device.wda_file | default('/dev/null') }}|{{ device.wda_bundleid | default('com.facebook.WebDriverAgentRunner.xctrunner') }}
+{{ device.id }}|{{ device.os }}|{{ device.name }}|{{ device.location | default('') }}|{{ device.appium_port }}|{{ device.adb_port }}|{{ device.proxy_port | default('0') }}|{{ device.server_proxy_port | default('0') }}|{{ device.min_port }}|{{ device.max_port }}|{{ device.wireless | default('false') }}|{{ device.wda_file | default('/dev/null') }}|{{ device.wda_bundleid | default('com.facebook.WebDriverAgentRunner.xctrunner') }}|{{ device.wda_host | default('') }}|{{ device.wda_port | default('') }}
 {% endfor %}

--- a/roles/mac-devices/templates/zebrunner-farm
+++ b/roles/mac-devices/templates/zebrunner-farm
@@ -121,6 +121,22 @@ function create_containers() {
   #echo "stf_min_port: $stf_min_port"
 
   local stf_max_port=$(cat ${devices} | grep "$udid" | cut -d '|' -f 10)
+
+  # Field 11 - 'wireless'.
+  # Marks a device with NO usb path, reached over a network tunnel maintained
+  # outside this script (for example an Apple TV 4K, which has no diagnostic port at
+  # all, reached over Apple's RemoteXPC tunnel). The field has existed in
+  # mcloud-devices.txt since it was introduced but was never read; 'false' keeps
+  # every existing row behaving exactly as before.
+  local wireless=$(cat ${devices} | grep "$udid" | cut -d '|' -f 11)
+
+  # Fields 14 / 15 - 'wda_host' and 'wda_port'.
+  # Where WebDriverAgent is reachable for a WIRELESS device. The tunnel owner on the
+  # host publishes WDA on a routable TCP endpoint and these point at it. For a usb
+  # device both stay empty: the connector container owns WDA and is reached over a
+  # docker --link instead.
+  local wda_host=$(cat ${devices} | grep "$udid" | cut -d '|' -f 14)
+  local wda_port=$(cat ${devices} | grep "$udid" | cut -d '|' -f 15)
   #echo "stf_max_port: $stf_max_port"
 
   local net={{ STF_DOCKER_NETWORK }}
@@ -166,23 +182,62 @@ function create_containers() {
     fi
     echo -e "wdaBundleId: $wdaBundleId\n"
 
-    echo -n "device-${device_name_underscored}-${udid}-connector:  "
-    docker run -itd --name device-${device_name_underscored}-${udid}-connector \
-      --log-driver=local \
-      --log-opt max-size=256m \
-      --log-opt max-file=2 \
-      --net=${net} \
-      --restart on-failure:{{ RESTARTS_LIMIT }} $DEVICE_ARG \
-      -e USBMUXD_SOCKET_ADDRESS={{ USBMUXD_SOCKET_ADDRESS }} \
-      -e HOST_OS=DARWIN \
-      -e DEVICE_BUS=$usb_bus \
-      -e WDA_BUNDLEID=$wdaBundleId \
-      -e WDA_FILE=/tmp/zebrunner/WebDriverAgent.ipa \
-      -v ${wdaIpaPath}:/tmp/zebrunner/WebDriverAgent.ipa \
-      -v device-${device_name_underscored}-${udid}-lockdown:/var/lib/lockdown \
-      -v device-${device_name_underscored}-${udid}:/tmp/log \
-      -e DEVICE_UDID=$udid \
-      {{ IOS_CONNECTOR_IMAGE }}:{{ IOS_CONNECTOR_VERSION }} || echo 'already created'
+    # How the device and appium containers reach WebDriverAgent is the only thing
+    # that differs for a wireless device:
+    #
+    #   usb      - the connector container owns WDA. Containers --link to it and
+    #              address it as host 'connector' (the historical behaviour).
+    #   wireless - WDA is published by the tunnel owner on the host. There is no
+    #              connector container to link, so WDA_HOST/WDA_PORT address it
+    #              directly. WIRELESS=true additionally tells the device and appium
+    #              containers to skip their usbmuxd clients, which cannot work here.
+    #
+    # No change is needed in the appium image: it already builds
+    # 'appium:webDriverAgentUrl' as http://${WDA_HOST}:${WDA_PORT} (see
+    # zbr-default-caps-gen.sh), so pointing those two variables elsewhere is enough.
+    #
+    # NOTE on the expansion form used below: macOS ships bash 3.2, where
+    # "${arr[@]}" on an EMPTY array is an unbound-variable error under `set -u`.
+    # ${arr[@]+"${arr[@]}"} is the portable form and preserves element quoting.
+    local wda_link_args=()
+    local wda_env_args=(-e WDA_HOST=connector -e WDA_PORT=8100)
+    if [ "$wireless" == "true" ]; then
+      if [ -z "$wda_host" ]; then
+        echo "ERROR! device $udid has wireless=true but no wda_host in field 14 of mcloud-devices.txt"
+        echo "       A wireless device cannot be reached without a published WebDriverAgent endpoint."
+        return 1
+      fi
+      if [ -z "$wda_port" ]; then
+        wda_port=8100
+      fi
+      echo "wireless device: WDA at ${wda_host}:${wda_port} (no connector container)"
+      wda_env_args=(-e WDA_HOST=$wda_host -e WDA_PORT=$wda_port -e WIRELESS=true)
+    else
+      wda_link_args=(--link device-${device_name_underscored}-${udid}-connector:connector)
+    fi
+
+    # The connector exists purely to share usbmuxd into the other containers. A
+    # wireless device has no usbmuxd path, so it is skipped entirely rather than
+    # started and left failing.
+    if [ "$wireless" != "true" ]; then
+      echo -n "device-${device_name_underscored}-${udid}-connector:  "
+      docker run -itd --name device-${device_name_underscored}-${udid}-connector \
+        --log-driver=local \
+        --log-opt max-size=256m \
+        --log-opt max-file=2 \
+        --net=${net} \
+        --restart on-failure:{{ RESTARTS_LIMIT }} $DEVICE_ARG \
+        -e USBMUXD_SOCKET_ADDRESS={{ USBMUXD_SOCKET_ADDRESS }} \
+        -e HOST_OS=DARWIN \
+        -e DEVICE_BUS=$usb_bus \
+        -e WDA_BUNDLEID=$wdaBundleId \
+        -e WDA_FILE=/tmp/zebrunner/WebDriverAgent.ipa \
+        -v ${wdaIpaPath}:/tmp/zebrunner/WebDriverAgent.ipa \
+        -v device-${device_name_underscored}-${udid}-lockdown:/var/lib/lockdown \
+        -v device-${device_name_underscored}-${udid}:/tmp/log \
+        -e DEVICE_UDID=$udid \
+        {{ IOS_CONNECTOR_IMAGE }}:{{ IOS_CONNECTOR_VERSION }} || echo 'already created'
+    fi
 
     # Linking with apppium required to share usbmuxd via socat
     echo -n "device-${device_name_underscored}-${udid}:            "
@@ -192,8 +247,8 @@ function create_containers() {
       --log-opt max-file=2 \
       --net=${net} \
       --restart on-failure:{{ RESTARTS_LIMIT }} \
-      --link device-${device_name_underscored}-${udid}-connector:connector \
-      -e WDA_HOST=connector \
+      ${wda_link_args[@]+"${wda_link_args[@]}"} \
+      ${wda_env_args[@]+"${wda_env_args[@]}"} \
       -e WDA_WAIT_TIMEOUT=60 \
       -e PLATFORM_NAME=$platform_name \
       -e STF_PROVIDER_DEVICE_NAME="${device_name}" \
@@ -224,8 +279,8 @@ function create_containers() {
       --net=${net} \
       --restart on-failure:{{ RESTARTS_LIMIT }} $DEVICE_ARG \
       --link device-${device_name_underscored}-${udid}:device \
-      --link device-${device_name_underscored}-${udid}-connector:connector \
-      -e WDA_HOST=connector \
+      ${wda_link_args[@]+"${wda_link_args[@]}"} \
+      ${wda_env_args[@]+"${wda_env_args[@]}"} \
       -v appium-storage-volume:/opt/appium-storage \
       -v device-${device_name_underscored}-${udid}:/tmp/log \
       -e TASK_LOG=/tmp/log/appium.log \


### PR DESCRIPTION
## Problem

Apple TV 4K has no diagnostic port. `ios listen` therefore never emits a connect event for it, so `create_containers()` is never called and the device cannot join the farm at all.

The device *is* reachable — over Apple's RemoteXPC tunnel — but that tunnel needs uid 0 and a tun interface on the host, so it lives outside the container set.

## Key insight

Almost nothing in the stack actually needs USB. The parts that matter are already HTTP- and env-driven:

- the appium image builds `appium:webDriverAgentUrl` from `WDA_HOST`/`WDA_PORT` (`files/zbr-default-caps-gen.sh`)
- the device image registers with STF as `--serial ${DEVICE_UDID}` from env, and health-checks WDA with `curl`
- `appium-xcuitest-driver` **explicitly supports running off macOS** when given `webDriverAgentUrl` — see `assertWdaHostSessionCapsSupported()`, which returns early for `darwin` and otherwise *requires* that capability

So the only genuine difference for a portless device is **where WebDriverAgent lives**.

## Change

Honour the `wireless` field that has been in `mcloud-devices.txt` since it was introduced and was never read (fields 2–10, 12 and 13 are read; 11 is skipped).

For rows with `wireless=true`:

- skip the `connector` container — it exists only to share usbmuxd
- omit the `--link` to it from the device and appium containers
- set `WDA_HOST`/`WDA_PORT` from two new fields (14, 15) so both containers address the host-published WDA directly
- pass `WIRELESS=true` to the device and appium containers

Rows without `wireless=true` are untouched — same `--link`, same `WDA_HOST=connector`, same connector container.

## Backward compatibility

Verified by simulating `create_containers()` for both branches: the docker arguments generated for a USB row are **byte-identical** to before.

`WDA_PORT` is now passed explicitly on the USB path too — checked that both `mcloud-device` and `appium` already default it to `8100`, so this is a genuine no-op.

Fails fast with an explicit message if `wireless=true` but `wda_host` is missing, rather than starting containers that cannot work.

## Note on the array expansion

`${arr[@]+"${arr[@]}"}` rather than `"${arr[@]}"`, because macOS ships **bash 3.2**, where the latter on an empty array is an unbound-variable error under `set -u`. Tested on 3.2.57.

## Verification

Verified end to end on an Apple TV 4K (`AppleTV14,1`) on **tvOS 18.4 and 26.6**, driving the device from a Linux container with no Xcode, no macOS and no tunnel access — i.e. exactly the environment the appium image runs in:

```
POST /wd/hub/session        -> 200
GET  /source                -> 8074 bytes of XCUIElementType tree
GET  /screenshot            -> valid PNG
mobile: pressButton {menu}  -> {"value":null}
mobile: activeAppInfo       -> com.apple.PineBoard
```

## What we own, so you do not have to

Per Mac host, outside Docker: the RemoteXPC tunnel daemon (uid 0, one per host), WebDriverAgent lifecycle on the device, publishing WDA on a TCP endpoint (the same shape as your `USBMUXD_SOCKET_ADDRESS` socat bridge, different backend), and pairing (needs mDNS and a human at the TV, one-time per device).


---

## Companion PRs — all three land together

These are one change split across three repos. Reviewed in isolation, PRs 2 and 3 look like no-ops: they consume the `WIRELESS=true` that PR 1 sets.

| Order | Repo | PR | Change |
|---|---|---|---|
| 1 | `mcloud-agent` | zebrunner/mcloud-agent#414 | honour the `wireless` device-list field; sets `WIRELESS=true`, `WDA_HOST`, `WDA_PORT` |
| 2 | `mcloud-device` | zebrunner/mcloud-device#210 | skip usbmuxd setup when `WIRELESS=true` |
| 3 | `appium` | zebrunner/appium#439 | skip usbmuxd setup in `ios.sh` when `WIRELESS=true` |

**Suggested merge order: 2 and 3 first, then 1.** The two consumers are inert until a device row sets `wireless=true`, so merging them ahead of PR 1 carries no behaviour change at all. Merging PR 1 first would leave a window where a `wireless=true` row starts containers whose images still insist on usbmuxd.

Every row without `wireless=true` behaves exactly as it does today, in all three repos.
